### PR TITLE
Refactor server-side job config

### DIFF
--- a/kbatch-proxy/kbatch_proxy/patch.py
+++ b/kbatch-proxy/kbatch_proxy/patch.py
@@ -16,48 +16,43 @@ from kubernetes.client.models import (
     V1KeyToPath,
     V1OwnerReference,
     V1EnvVar,
-    V1Affinity,
-    V1NodeAffinity,
-    V1NodeSelector,
-    V1NodeSelectorTerm,
-    V1NodeSelectorRequirement,
 )
 
 
 SAFE_CHARS = set(string.ascii_lowercase + string.digits)
 
 
-def add_node_affinity(
-    job: V1Job,
-    job_node_affinity_required_label_key: Optional[str],
-    job_node_affinity_required_label_value: Optional[str],
-) -> None:
-    if job_node_affinity_required_label_value and job_node_affinity_required_label_key:
-        affinity = V1Affinity(
-            node_affinity=V1NodeAffinity(
-                required_during_scheduling_ignored_during_execution=V1NodeSelector(
-                    node_selector_terms=[
-                        V1NodeSelector(
-                            node_selector_terms=[
-                                V1NodeSelectorTerm(
-                                    match_expressions=[
-                                        V1NodeSelectorRequirement(
-                                            key=job_node_affinity_required_label_key,
-                                            operator="In",
-                                            values=[
-                                                job_node_affinity_required_label_value
-                                            ],
-                                        )
-                                    ]
-                                )
-                            ]
-                        )
-                    ]
-                )
-            )
-        )
-        pod_spec = job.spec.template.spec
-        pod_spec.affinity = affinity
+# def add_node_affinity(
+#     job: V1Job,
+#     job_node_affinity_required_label_key: Optional[str],
+#     job_node_affinity_required_label_value: Optional[str],
+# ) -> None:
+#     if job_node_affinity_required_label_value and job_node_affinity_required_label_key:
+#         affinity = V1Affinity(
+#             node_affinity=V1NodeAffinity(
+#                 required_during_scheduling_ignored_during_execution=V1NodeSelector(
+#                     node_selector_terms=[
+#                         V1NodeSelector(
+#                             node_selector_terms=[
+#                                 V1NodeSelectorTerm(
+#                                     match_expressions=[
+#                                         V1NodeSelectorRequirement(
+#                                             key=job_node_affinity_required_label_key,
+#                                             operator="In",
+#                                             values=[
+#                                                 job_node_affinity_required_label_value
+#                                             ],
+#                                         )
+#                                     ]
+#                                 )
+#                             ]
+#                         )
+#                     ]
+#                 )
+#             )
+#         )
+#         pod_spec = job.spec.template.spec
+#         pod_spec.affinity = affinity
 
 
 def add_annotations(job: V1Job, annotations, username: str) -> None:
@@ -199,8 +194,6 @@ def patch(
     extra_env: Optional[Dict[str, str]] = None,
     api_token: Optional[str] = None,
     ttl_seconds_after_finished: Optional[int] = 3600,
-    job_node_affinity_required_label_key: Optional[str] = None,
-    job_node_affinity_required_label_value: Optional[str] = None,
 ) -> None:
     """
     Updates the Job inplace with the following modifications:
@@ -215,11 +208,6 @@ def patch(
     extra_env = extra_env or {}
 
     add_annotations(job, annotations, username)
-    add_node_affinity(
-        job,
-        job_node_affinity_required_label_key,
-        job_node_affinity_required_label_value,
-    )
     add_labels(job, labels, username)
     add_namespace(job, namespace_for_username(username))
     add_extra_env(job, extra_env, api_token)

--- a/kbatch-proxy/kbatch_proxy/utils.py
+++ b/kbatch-proxy/kbatch_proxy/utils.py
@@ -19,7 +19,10 @@ def parse(d, model):
     parsed = {}
 
     for field, type_ in model.openapi_types.items():
-        value = d[field]
+        if field not in d and field in model.attribute_map:
+            # node_affinity -> nodeAffinity
+            field = model.attribute_map[field]
+        value = d.get(field, None)  # is this a good default?
         if value is None:
             parsed[field] = value
         elif type_ in basic_types:
@@ -33,8 +36,46 @@ def parse(d, model):
             raise NotImplementedError("TODO")
         else:
             parsed[field] = parse(d[field], getattr(kubernetes.client, type_))
+
+        # rewrite
+        reverse_map = {v: k for k, v in model.attribute_map.items()}
+        parsed = {reverse_map.get(k, k): v for k, v in parsed.items()}
+
     return model(**parsed)
 
 
 def validate_namespace(d: kubernetes.client.models.V1Job):
     pass
+
+
+def merge_json_objects(a, b):
+    """Merge two JSON objects recursively.
+    - If a dict, keys are merged, preferring ``b``'s values
+    - If a list, values from ``b`` are appended to ``a``
+    Copying is minimized. No input collection will be mutated, but a deep copy
+    is not performed.
+    Parameters
+    ----------
+    a, b : dict
+        JSON objects to be merged.
+    Returns
+    -------
+    merged : dict
+    """
+    # see https://github.com/dask/dask-gateway/blob/7d1659db8b2122d1a861ea820a459fd045fc3f02/
+    # dask-gateway-server/dask_gateway_server/backends/kubernetes/utils.py#L220
+    if b:
+        # Use a shallow copy here to avoid needlessly copying
+        a = a.copy()
+        for key, b_val in b.items():
+            if key in a:
+                a_val = a[key]
+                if isinstance(a_val, dict) and isinstance(b_val, dict):
+                    a[key] = merge_json_objects(a_val, b_val)
+                elif isinstance(a_val, list) and isinstance(b_val, list):
+                    a[key] = a_val + b_val
+                else:
+                    a[key] = b_val
+            else:
+                a[key] = b_val
+    return a

--- a/kbatch-proxy/tests/job_template.yaml
+++ b/kbatch-proxy/tests/job_template.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: hub.jupyter.org/node-purpose
+                  operator: In
+                  values:
+                    - user

--- a/kbatch-proxy/tests/test_proxy.py
+++ b/kbatch-proxy/tests/test_proxy.py
@@ -1,9 +1,15 @@
+import pathlib
+
 import pytest
 import kubernetes.client
+import yaml
 
 import kbatch_proxy.utils
 import kbatch_proxy.main
 import kbatch_proxy.patch
+
+
+HERE = pathlib.Path(__file__).parent
 
 
 @pytest.fixture
@@ -177,22 +183,18 @@ def test_set_job_ttl_seconds_after_finished(k8s_job: kubernetes.client.V1Job):
 
 
 def test_add_node_affinity(k8s_job: kubernetes.client.V1Job):
-    kbatch_proxy.patch.patch(
-        k8s_job,
-        None,
-        username="foo",
-        job_node_affinity_required_label_key="hub.jupyter.org/node-purpose",
-        job_node_affinity_required_label_value="user",
-    )
+    job_template = yaml.safe_load((HERE / "job_template.yaml").read_text())
 
-    node_affinity = k8s_job.spec.template.spec.affinity.node_affinity
-    terms = (
-        node_affinity.required_during_scheduling_ignored_during_execution.node_selector_terms[
-            0
-        ]
-        .node_selector_terms[0]
-        .match_expressions[0]
-    )
+    job_data = k8s_job.to_dict()
+    result = kbatch_proxy.utils.merge_json_objects(job_data, job_template)
+    result = kbatch_proxy.utils.parse(result, kubernetes.client.V1Job)
+
+    node_affinity = result.spec.template.spec.affinity.node_affinity
+    terms = node_affinity.required_during_scheduling_ignored_during_execution.node_selector_terms[
+        0
+    ].match_expressions[
+        0
+    ]
     assert terms.key == "hub.jupyter.org/node-purpose"
     assert terms.operator == "In"
     assert terms.values == ["user"]


### PR DESCRIPTION
Followup to #17.

Now instead of manually plumbing stuff through, we have the admin optionally define a job template that's applied to each job.

For example, this job template will assign jobs to user nodes:

```yaml
apiVersion: batch/v1
kind: Job
spec:
  template:
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                - key: hub.jupyter.org/node-purpose
                  operator: In
                  values:
                    - user
```

This works well for configuring the Job / pod. For things touching the container, I think we'll still need the manual patching stuff.