### PR TITLE
Re-raise Kubernetes exceptions as HttpError

### DIFF
--- a/kbatch-proxy/kbatch_proxy/main.py
+++ b/kbatch-proxy/kbatch_proxy/main.py
@@ -232,7 +232,15 @@ async def create_job(request: Request, user: User = Depends(get_current_user)):
         patch.add_submitted_configmap_name(job, config_map)
 
     logger.info("Submitting job")
-    resp = batch_api.create_namespaced_job(namespace=user.namespace, body=job)
+    try:
+        resp = batch_api.create_namespaced_job(namespace=user.namespace, body=job)
+    except kubernetes.client.exceptions.ApiException as e:
+        content_type = e.headers.get("Content-Type")
+        if content_type:
+            headers = {"Content-Type": content_type}
+        else:
+            headers = {}
+        raise HTTPException(status_code=e.status, detail=e.body, headers=headers)
 
     if config_map:
         logger.info(

--- a/kbatch/kbatch/_core.py
+++ b/kbatch/kbatch/_core.py
@@ -1,6 +1,7 @@
 import datetime
 import base64
 import os
+import logging
 import json
 from pathlib import Path
 from typing import Optional, Dict, Union
@@ -11,6 +12,9 @@ import urllib.parse
 
 from ._types import Job
 from ._backend import make_configmap
+
+
+logger = logging.getLogger(__name__)
 
 
 def config_path() -> Path:
@@ -208,7 +212,11 @@ def submit_job(
         json=data,
         headers=headers,
     )
-    r.raise_for_status()
+    try:
+        r.raise_for_status()
+    except Exception:
+        logger.exception(r.json())
+        raise
 
     return r.json()
 

--- a/kbatch/kbatch/cli.py
+++ b/kbatch/kbatch/cli.py
@@ -1,12 +1,23 @@
 import json
+import logging
 from pathlib import Path
 
 import click
 import rich
+import rich.logging
 import yaml
 
 from . import _core
 from ._types import Job
+
+
+FORMAT = "%(message)s"
+logging.basicConfig(
+    level=logging.INFO,
+    format=FORMAT,
+    datefmt="[%X]",
+    handlers=[rich.logging.RichHandler()],
+)
 
 
 @click.group()


### PR DESCRIPTION
Here's the CLI output now:

```console
❯ kbatch job submit --name=TEST --image="alpine"
[14:22:15] ERROR    {'detail': '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Job.batch \\"TEST-6c6wr\\" is invalid: [metadata.generateName: Invalid value: \\"TEST-\\": a DNS-1123 subdomain must consist of lower case         _core.py:226
                    alphanumeric characters, \'-\' or \'.\', and must start and end with an alphanumeric character (e.g. \'example.com\', regex used for validation is \'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\'), metadata.name:
                    Invalid value: \\"TEST-6c6wr\\": a DNS-1123 subdomain must consist of lower case alphanumeric characters, \'-\' or \'.\', and must start and end with an alphanumeric character (e.g. \'example.com\', regex used for validation is
                    \'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\')]","reason":"Invalid","details":{"name":"TEST-6c6wr","group":"batch","kind":"Job","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \\"TEST-\\": a
                    DNS-1123 subdomain must consist of lower case alphanumeric characters, \'-\' or \'.\', and must start and end with an alphanumeric character (e.g. \'example.com\', regex used for validation is
                    \'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\')","field":"metadata.generateName"},{"reason":"FieldValueInvalid","message":"Invalid value: \\"TEST-6c6wr\\": a DNS-1123 subdomain must consist of lower case
                    alphanumeric characters, \'-\' or \'.\', and must start and end with an alphanumeric character (e.g. \'example.com\', regex used for validation is
                    \'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\')","field":"metadata.name"}]},"code":422}\n'}
                    Traceback (most recent call last):
                      File "/home/taugspurger/src/kbatch-dev/kbatch/kbatch/kbatch/_core.py", line 224, in submit_job
                        r.raise_for_status()
                      File "/home/taugspurger/miniconda3/envs/ksubmit-server/lib/python3.9/site-packages/httpx/_models.py", line 1507, in raise_for_status
                        raise HTTPStatusError(message, request=request, response=self)
                    httpx.HTTPStatusError: Client error '422 Unprocessable Entity' for url 'http://localhost:8050/services/kbatch/jobs/'
                    For more information check: https://httpstatuses.com/422
Traceback (most recent call last):
  File "/home/taugspurger/miniconda3/envs/ksubmit-server/bin/kbatch", line 33, in <module>
    sys.exit(load_entry_point('kbatch', 'console_scripts', 'kbatch')())
  File "/home/taugspurger/miniconda3/envs/ksubmit-server/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/taugspurger/miniconda3/envs/ksubmit-server/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/taugspurger/miniconda3/envs/ksubmit-server/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/taugspurger/miniconda3/envs/ksubmit-server/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/taugspurger/miniconda3/envs/ksubmit-server/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/taugspurger/miniconda3/envs/ksubmit-server/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/taugspurger/src/kbatch-dev/kbatch/kbatch/kbatch/cli.py", line 157, in submit
    result = _core.submit_job(
  File "/home/taugspurger/src/kbatch-dev/kbatch/kbatch/kbatch/_core.py", line 224, in submit_job
    r.raise_for_status()
  File "/home/taugspurger/miniconda3/envs/ksubmit-server/lib/python3.9/site-packages/httpx/_models.py", line 1507, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '422 Unprocessable Entity' for url 'http://localhost:8050/services/kbatch/jobs/'
For more information check: https://httpstatuses.com/422
```

Closes https://github.com/kbatch-dev/kbatch/issues/31.