### PR TITLE
Add requirements.txt back

### DIFF
--- a/kbatch-proxy/requirements.txt
+++ b/kbatch-proxy/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+httpx
+kubernetes
+uvicorn[standard]
+gunicorn==20.1.0
+jupyterhub
+escapism
+rich
+pydantic[dotenv]


### PR DESCRIPTION
Fixing issue that I caused when I removed `requirements.txt`. It is needed to build the docker images. Apologies for this oversight.

cc @TomAugspurger