### PR TITLE
Properly set for configmap owner

### DIFF
--- a/kbatch-proxy/kbatch_proxy/patch.py
+++ b/kbatch-proxy/kbatch_proxy/patch.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional, Union
 import escapism
 from kubernetes.client.models import (
     V1Job,
+    V1CronJob,
     V1JobTemplateSpec,
     V1ConfigMap,
     V1Container,
@@ -199,7 +200,7 @@ def add_submitted_configmap_name(
 
 
 def patch_configmap_owner(
-    job: Union[V1Job, V1JobTemplateSpec], config_map: V1ConfigMap
+    job: Union[V1Job, V1CronJob], config_map: V1ConfigMap
 ):
     if job.metadata.name is None:
         raise ValueError("job must have a name before it can be set as an owner")
@@ -207,7 +208,7 @@ def patch_configmap_owner(
 
     if issubclass(type(job), V1Job):
         kind = "Job"
-    elif issubclass(type(job), V1JobTemplateSpec):
+    else:
         kind = "CronJob"
 
     config_map.metadata.owner_references = [


### PR DESCRIPTION
When updating the owner for config map, ensure that the `kind` key is properly set. 