### PR TITLE
fixed profile loading and parsing

### DIFF
--- a/kbatch/kbatch/_core.py
+++ b/kbatch/kbatch/_core.py
@@ -384,6 +384,9 @@ def _prep_job_data(
         data["env"] = env
 
     if profile:
+        if kbatch_url is None:
+            kbatch_url = data["kbatch_url"]
         profile = load_profile(profile, kbatch_url)
+        data["profile"] = profile
 
     return data


### PR DESCRIPTION
When submitting a job through the kbatch CLI (`kbatch job submit`), argument `-p`, `--profile` gets ignored, resp. incorrectly treated.
See file [_core.py, line #389](https://github.com/kbatch-dev/kbatch/blob/1827cae164a53b73574bdddcfcd4d47d78613644/kbatch/kbatch/_core.py#L389): if a profile name is provided as a string, the profile details dict gets looked up and retrieved in function `load_profile`, but never added back to `data`.
I also took the liberty to add argument `kbatch_url` required for profile lookup as an option to the config YAML file.