### PR TITLE
Properly retrieve and parse config in job submission

### DIFF
--- a/kbatch/kbatch/_core.py
+++ b/kbatch/kbatch/_core.py
@@ -384,6 +384,9 @@ def _prep_job_data(
         data["env"] = env
 
     if profile:
+        if kbatch_url is None:
+            kbatch_url = data["kbatch_url"]
         profile = load_profile(profile, kbatch_url)
+        data["profile"] = profile
 
     return data

--- a/kbatch/kbatch/cli.py
+++ b/kbatch/kbatch/cli.py
@@ -153,7 +153,7 @@ def submit_cronjob(
         kbatch_url,
         env,
     )
-    profile = data.pop('profile', profile)
+    profile = data.pop("profile", profile)
 
     if schedule is not None:
         data["schedule"] = schedule
@@ -275,7 +275,7 @@ def submit_job(
         kbatch_url,
         env,
     )
-    profile = data.pop('profile', profile)
+    profile = data.pop("profile", profile)
 
     code = code or data.pop("code", None)
     job = Job(**data)

--- a/kbatch/kbatch/cli.py
+++ b/kbatch/kbatch/cli.py
@@ -274,6 +274,7 @@ def submit_job(
         kbatch_url,
         env,
     )
+    profile = data.pop('profile', profile)
 
     code = code or data.pop("code", None)
     job = Job(**data)

--- a/kbatch/kbatch/cli.py
+++ b/kbatch/kbatch/cli.py
@@ -153,6 +153,7 @@ def submit_cronjob(
         kbatch_url,
         env,
     )
+    profile = data.pop('profile', profile)
 
     if schedule is not None:
         data["schedule"] = schedule


### PR DESCRIPTION
Fixes a bug that retrieved profile dict if profile name specified in (cron-) job submission, but failed to convey dict further to create job.