### PR TITLE
Explicitly set docker image tag equal to current version

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -37,6 +37,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            ${{ env.VERSION }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4


### PR DESCRIPTION
The publish-image workflow is failing because the docker tags are not being set.