### PR TITLE
CI: move publish-charts wf from gh-pages branch to main

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -10,6 +10,7 @@ on:
   push:
     tags: 
       - "*"
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -1,6 +1,3 @@
-# This is a GitHub workflow defining a set of jobs with a set of steps. ref:
-# https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
-#
 # This workflow package and publishes the Helm charts to Helm repository living
 # inside the gh-pages branch of this git repository.
 #
@@ -25,7 +22,6 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
         run: |
           echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -1,0 +1,38 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps. ref:
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+#
+# This workflow package and publishes the Helm charts to Helm repository living
+# inside the gh-pages branch of this git repository.
+#
+name: Publish charts
+
+on:
+  push:
+    tags: 
+      - "*"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: |
+          echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: "kbatch-proxy/helm"
+          charts_url: https://kbatch-dev.github.io/kbatch/
+          linting: "off"
+          chart_version: ${{ env.VERSION }}


### PR DESCRIPTION
This workflow was in the `gh-pages` branch and wasn't being triggered when a new tag was created. This PR moves this workflow from the `gh-pages` branch to `main`. I also included a way to run the workflow using `workflow_dispatch`.

Thanks @TomAugspurger for all the PR reviews. 