### PR TITLE
Return profile after loading from kbatch url

### DIFF
--- a/kbatch/kbatch/_core.py
+++ b/kbatch/kbatch/_core.py
@@ -386,4 +386,4 @@ def _prep_job_data(
     if profile:
         profile = load_profile(profile, kbatch_url)
 
-    return data
+    return data, profile

--- a/kbatch/kbatch/cli.py
+++ b/kbatch/kbatch/cli.py
@@ -141,7 +141,7 @@ def submit_cronjob(
     Submit a CronJob to run on Kubernetes.
     """
 
-    data = _core._prep_job_data(
+    data, profile = _core._prep_job_data(
         file,
         code,
         name,

--- a/kbatch/kbatch/cli.py
+++ b/kbatch/kbatch/cli.py
@@ -262,7 +262,7 @@ def submit_job(
     Submit a job to run on Kubernetes.
     """
 
-    data = _core._prep_job_data(
+    data, profile = _core._prep_job_data(
         file,
         code,
         name,


### PR DESCRIPTION
While trying to use profiles I successfully loaded profiles onto kbatch_proxy, but got an error when trying to submit a job referencing the profile name.
ex: 
`kbatch job submit -f .\test-job.yaml --profile="python"`

I got the following error:
```
[18:23:03] INFO     HTTP Request: GET https://bbmplanetarycomputerhub.westeurope.cloudapp.azure.com/services/kbatch/profiles/ "HTTP/1.1 200 OK"                                                         _client.py:1027Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Python311\Scripts\kbatch.exe\__main__.py", line 7, in <module>    
  File "C:\Python311\Lib\site-packages\click\core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\kbatch\cli.py", line 281, in submit_job
    result = _core.submit_job(
             ^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\kbatch\_core.py", line 153, in submit_job
    data = make_job(job, profile=profile).to_dict()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\kbatch\_backend.py", line 242, in make_job
    job_spec = _make_job_spec(job, profile, labels, annotations)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\kbatch\_backend.py", line 89, in _make_job_spec
    resources = profile.get("resources", {})
                ^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'get'
```

after looking at the code, I noticed that loaded profile was never returned from `_core._prep_job_data` so the profile variable was just "python" instead of the full python profile as a dict.

Maybe I missed something but with these changes I got it working.