### PR TITLE
Raise response text with exception, not JSON

### DIFF
--- a/kbatch/kbatch/_core.py
+++ b/kbatch/kbatch/_core.py
@@ -116,7 +116,7 @@ def _request_action(
     try:
         r.raise_for_status()
     except Exception:
-        logger.exception(r.json())
+        logger.exception(r.text)
         raise
 
     return r.json()


### PR DESCRIPTION
If kbatch-proxy returns 5xx errors, those are not valid JSON but text.