### PR TITLE
implement scope-based auth, require jupyterhub 3

### DIFF
--- a/kbatch-proxy/setup.cfg
+++ b/kbatch-proxy/setup.cfg
@@ -18,7 +18,7 @@ install_requires =
     escapism
     fastapi
     httpx
-    jupyterhub
+    jupyterhub>=3
     kubernetes
     pydantic>=2,<3
     pydantic-settings


### PR DESCRIPTION
users must have e.g. `access:services!service=kbatch` scope, rather than allowing all valid JupyterHub tokens to use the service.

closes #69 