### PR TITLE
bump Python image in docker

### DIFF
--- a/kbatch-proxy/docker/local/Dockerfile
+++ b/kbatch-proxy/docker/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.12
 
 WORKDIR /code
 

--- a/kbatch-proxy/docker/production/Dockerfile
+++ b/kbatch-proxy/docker/production/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.9
+FROM python:3.12-slim
 
 WORKDIR /code
 
 COPY ./requirements.txt /code/requirements.txt
-RUN pip install --no-cache-dir --upgrade -r requirements.txt
+RUN pip install --no-cache-dir --upgrade --only-binary :all: -r requirements.txt
 COPY ./docker/production/gunicorn_conf.py /code/
 COPY ./kbatch_proxy /code/kbatch_proxy
 


### PR DESCRIPTION
3.9 -> 3.12

use slim for smaller production image (~360 MB vs ~1.2 GB)