### PR TITLE
default to more concise output in cli

### DIFF
--- a/kbatch/kbatch/cli.py
+++ b/kbatch/kbatch/cli.py
@@ -86,7 +86,7 @@ def delete_cronjob(cronjob_name, kbatch_url, token):
     "--output",
     help="output format",
     type=click.Choice(["json", "table"]),
-    default="json",
+    default="table",
 )
 def list_cronjobs(kbatch_url, token, output):
     """List all the cronjobs."""
@@ -118,7 +118,7 @@ def list_cronjobs(kbatch_url, token, output):
 @click.option(
     "-o",
     "--output",
-    default="json",
+    default="name",
     help="Output format.",
     type=click.Choice(["json", "name"]),
 )
@@ -209,7 +209,7 @@ def delete_job(job_name, kbatch_url, token):
     "--output",
     help="output format",
     type=click.Choice(["json", "table"]),
-    default="json",
+    default="table",
 )
 def list_jobs(kbatch_url, token, output):
     """List all the jobs."""
@@ -240,7 +240,7 @@ def list_jobs(kbatch_url, token, output):
 @click.option(
     "-o",
     "--output",
-    default="json",
+    default="name",
     help="Output format.",
     type=click.Choice(["json", "name"]),
 )
@@ -310,7 +310,7 @@ def pod():
     "--output",
     help="output format",
     type=click.Choice(["json", "table", "name"]),
-    default="json",
+    default="table",
 )
 def list_pods(kbatch_url, token, job_name, output):
     """List all the pods."""


### PR DESCRIPTION
make raw, complete json opt-in instead of opt-out

use 'table' and 'name' outputs by default, where available

options are unchanged, so anything that specified explicit format via `-o json` still gets that.

closes #64
