### PR TITLE
add pending/running to job status

### DIFF
--- a/kbatch/kbatch/__init__.py
+++ b/kbatch/kbatch/__init__.py
@@ -3,13 +3,14 @@ kbatch
 """
 
 from ._core import (
-    list_jobs,
-    submit_job,
     configure,
-    show_job,
-    logs,
+    format_jobs,
+    list_jobs,
     list_pods,
+    logs,
     logs_streaming,
+    show_job,
+    submit_job,
 )
 from ._types import Job, CronJob
 from ._backend import make_job, make_cronjob
@@ -27,6 +28,7 @@ __all__ = [
     "make_cronjob",
     "configure",
     "show_job",
+    "format_jobs",
     "logs",
     "list_pods",
     "logs_streaming",

--- a/kbatch/kbatch/__init__.py
+++ b/kbatch/kbatch/__init__.py
@@ -4,6 +4,7 @@ kbatch
 
 from ._core import (
     configure,
+    delete_job,
     format_jobs,
     list_jobs,
     list_pods,
@@ -20,16 +21,17 @@ __version__ = "0.4.2"
 
 __all__ = [
     "__version__",
-    "Job",
-    "CronJob",
-    "list_jobs",
-    "submit_job",
-    "make_job",
-    "make_cronjob",
     "configure",
-    "show_job",
+    "CronJob",
+    "Job",
+    "delete_job",
     "format_jobs",
-    "logs",
+    "list_jobs",
     "list_pods",
     "logs_streaming",
+    "logs",
+    "make_cronjob",
+    "make_job",
+    "show_job",
+    "submit_job",
 ]

--- a/kbatch/kbatch/_core.py
+++ b/kbatch/kbatch/_core.py
@@ -201,9 +201,9 @@ def submit_job(
 
 
 def list_pods(
+    job_name: Optional[str] = None,
     kbatch_url: str | None = None,
     token: str | None = None,
-    job_name: Optional[str] = None,
 ):
     client = httpx.Client(follow_redirects=True)
     config = load_config()

--- a/kbatch/kbatch/_core.py
+++ b/kbatch/kbatch/_core.py
@@ -333,7 +333,9 @@ def format_jobs(data):
     table.add_column("status")
     table.add_column("duration")
 
-    for job in data["items"]:
+    for job in sorted(
+        data["items"], key=lambda job: job["metadata"]["creation_timestamp"]
+    ):
         table.add_row(
             job["metadata"]["name"],
             job["metadata"]["creation_timestamp"],

--- a/kbatch/kbatch/cli.py
+++ b/kbatch/kbatch/cli.py
@@ -314,7 +314,7 @@ def pod():
 )
 def list_pods(kbatch_url, token, job_name, output):
     """List all the pods."""
-    result = _core.list_pods(kbatch_url, token, job_name)
+    result = _core.list_pods(job_name, kbatch_url, token)
 
     if output == "json":
         rich.print_json(data=result)

--- a/kbatch/tests/test_core.py
+++ b/kbatch/tests/test_core.py
@@ -210,7 +210,7 @@ def test_list_jobs(respx_mock: respx.MockRouter):
         return_value=httpx.Response(200, json=data)
     )
 
-    result = kbatch.list_jobs("http://kbatch.com/", token="abc")
+    result = kbatch.list_jobs(kbatch_url="http://kbatch.com/", token="abc")
     assert result == data
 
 
@@ -220,7 +220,7 @@ def test_list_pods(respx_mock: respx.MockRouter):
         return_value=httpx.Response(200, json=data)
     )
 
-    result = kbatch.list_pods("http://kbatch.com/", token="abc")
+    result = kbatch.list_pods(kbatch_url="http://kbatch.com/", token="abc")
     assert result == data
 
 


### PR DESCRIPTION
previously, there was only 'active', now when there are 'ready' pods, report bold **running**, and when there are active but not ready pods, report "pending".

Changes:

- 'active' status is split into "pending" and "running"
- jobs are sorted by creation date
- add a couple missing methods to the `kbatch.__init__` namespace

Sample:

<img width="599" alt="Screenshot 2024-09-25 at 11 57 55" src="https://github.com/user-attachments/assets/ddc50bec-6f89-47b7-9c8e-3205264d3b5c">

