### PR TITLE
Improve error handling and propagation

### DIFF
--- a/kbatch-proxy/tests/test_app.py
+++ b/kbatch-proxy/tests/test_app.py
@@ -67,5 +67,5 @@ def test_error_handling(mock_hub_auth):
     response = client.get("/jobs/nosuchjob", headers={"Authorization": "token abc"})
     err = json.loads(response.read().decode("utf8"))
     assert response.status_code == 404
-    assert err["code"] == 404
-    assert "nosuchjob" in err["message"]
+    assert "detail" in err
+    assert "nosuchjob" in err["detail"]

--- a/kbatch-proxy/tests/test_app.py
+++ b/kbatch-proxy/tests/test_app.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 import pytest
@@ -38,8 +39,7 @@ def test_read_main():
     assert response.json() == {"message": "kbatch"}
 
 
-@pytest.mark.usefixtures("mock_hub_auth")
-def test_authorized():
+def test_authorized(mock_hub_auth):
     response = client.get("/authorized")
     assert response.status_code == 401
 
@@ -61,3 +61,11 @@ def test_loads_profile():
     subprocess.check_output(
         f"KBATCH_PROFILE_FILE={profile} {sys.executable} -c '{code}'", shell=True
     )
+
+
+def test_error_handling(mock_hub_auth):
+    response = client.get("/jobs/nosuchjob", headers={"Authorization": "token abc"})
+    err = json.loads(response.read().decode("utf8"))
+    assert response.status_code == 404
+    assert err["code"] == 404
+    assert "nosuchjob" in err["message"]

--- a/kbatch/kbatch/__main__.py
+++ b/kbatch/kbatch/__main__.py
@@ -1,0 +1,4 @@
+if __name__ == "__main__":
+    from kbatch.cli import main
+
+    main()

--- a/kbatch/kbatch/_core.py
+++ b/kbatch/kbatch/_core.py
@@ -131,11 +131,7 @@ def _request_action(
         headers=headers,
         json=json_data,
     )
-    try:
-        r.raise_for_status()
-    except Exception:
-        logger.exception(r.text)
-        raise
+    r.raise_for_status()
 
     return r.json()
 

--- a/kbatch/setup.cfg
+++ b/kbatch/setup.cfg
@@ -40,7 +40,7 @@ docs =
 
 [options.entry_points]
 console_scripts =
-    kbatch = kbatch.cli:cli
+    kbatch = kbatch.cli:main
 
 [flake8]
 exclude =


### PR DESCRIPTION
Changes:

- proxy: relay all kubernetes API errors back to the user, not just `create_namespaced_job`
- client: show error status and detail without traceback for HTTPStatus errors, and without HTTP request logs

As a result, invalid input like

```
kbatch job submit --name=List-files --command='["ls", "-lh"]' --image=alpine
```

goes from producing large amounts of output with no actionable info because of a generic 500 error and traceback:

```
[18:02:21] INFO     HTTP Request: GET https://pccompute.westeurope.cloudapp.azure.com/compute/services/kbatch/jobs/logs/add-coastline-distances-job-q6pbj/ "HTTP/1.1 500 Internal Server Error"      _client.py:1026
Traceback (most recent call last):
  File "/Users/calkoen/mambaforge/envs/jl-full/bin/kbatch", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/calkoen/mambaforge/envs/jl-full/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/calkoen/mambaforge/envs/jl-full/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/calkoen/mambaforge/envs/jl-full/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/calkoen/mambaforge/envs/jl-full/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/calkoen/mambaforge/envs/jl-full/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/calkoen/mambaforge/envs/jl-full/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/calkoen/mambaforge/envs/jl-full/lib/python3.11/site-packages/kbatch/cli.py", line 348, in logs
    result = _core.logs(pod_name, kbatch_url, token, read_timeout=read_timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/calkoen/mambaforge/envs/jl-full/lib/python3.11/site-packages/kbatch/_core.py", line 196, in logs
    result = next(gen)
             ^^^^^^^^^
  File "/Users/calkoen/mambaforge/envs/jl-full/lib/python3.11/site-packages/kbatch/_core.py", line 233, in _logs
    r.raise_for_status()
  File "/Users/calkoen/mambaforge/envs/jl-full/lib/python3.11/site-packages/httpx/_models.py", line 761, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Server error '500 Internal Server Error' for url 'https://pccompute.westeurope.cloudapp.azure.com/compute/services/kbatch/jobs/logs/add-coastline-distances-job-q6pbj/'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
```

to a short(-ish, depending on the kubernetes error), actionable error:

```
$ kbatch job submit --name=List-files --command='["ls", "-lh"]' --image=alpine
kbatch-proxy error 422: Job.batch "List-files-45l74" is invalid: [metadata.generateName: Invalid value: "List-files-": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), metadata.name: Invalid value: "List-files-45l74": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]
```

This is especially improved for 404s, where `kbatch pod logs nosuchpod` would produce the same big 500 traceback, but now gets the short and clear:

```
kbatch-proxy error 404: pods "nosuchpod" not found
```

I'd say this closes #52 . I don't think we need to support names k8s doesn't, and this gives users the right error to know what they need to change.
