### PR TITLE
Add duration information of failed jobs.

### DIFF
--- a/kbatch/kbatch/_core.py
+++ b/kbatch/kbatch/_core.py
@@ -340,7 +340,11 @@ def duration(job) -> str:
     if job["status"]["succeeded"]:
         end_time = datetime.datetime.fromisoformat(job["status"]["completion_time"])
     elif job["status"]["failed"]:
-        end_time = datetime.datetime.fromisoformat(job["status"]["conditions"][0]["last_transition_time"])
+        end_time = None
+        for condition in job["status"]["conditions"]:
+            if condition["type"] == "Failed":
+                end_time = datetime.datetime.fromisoformat(condition["last_transition_time"])
+                break
     else:
         end_time = datetime.datetime.now(tz=datetime.timezone.utc)
 

--- a/kbatch/kbatch/_core.py
+++ b/kbatch/kbatch/_core.py
@@ -340,7 +340,7 @@ def duration(job) -> str:
     if job["status"]["succeeded"]:
         end_time = datetime.datetime.fromisoformat(job["status"]["completion_time"])
     elif job["status"]["failed"]:
-        end_time = None
+        end_time = datetime.datetime.fromisoformat(job["status"]["conditions"][0]["last_transition_time"])
     else:
         end_time = datetime.datetime.now(tz=datetime.timezone.utc)
 

--- a/kbatch/kbatch/_core.py
+++ b/kbatch/kbatch/_core.py
@@ -343,7 +343,9 @@ def duration(job) -> str:
         end_time = None
         for condition in job["status"]["conditions"]:
             if condition["type"] == "Failed":
-                end_time = datetime.datetime.fromisoformat(condition["last_transition_time"])
+                end_time = datetime.datetime.fromisoformat(
+                    condition["last_transition_time"]
+                )
                 break
     else:
         end_time = datetime.datetime.now(tz=datetime.timezone.utc)


### PR DESCRIPTION
Hi,

Currently, listing the jobs does not show the duration of failed jobs.
However, the job dictionary actually has the last time the pod was probed, under `job["status"]["conditions"][0]["last_transition_time"]` (the key `"last_probe_time"` details the same information).

By using this timestamp, we can return the duration of failed jobs.